### PR TITLE
allow vimeo option "background" for plus user

### DIFF
--- a/php/class-oembed.php
+++ b/php/class-oembed.php
@@ -392,6 +392,7 @@ class FVP_oEmbed {
 				'loop',
 				'api',
 				'player_id',
+				'background',
 			),
 
 			// DailyMotion.com


### PR DESCRIPTION
Plus, Pro and Business Vimeo user can use the background parameter so better to allow it ?

https://help.vimeo.com/hc/en-us/articles/115011183028-Embedding-background-videos