### PR TITLE
& delimiter in src url not working when multiple parameters

### DIFF
--- a/php/class-oembed.php
+++ b/php/class-oembed.php
@@ -459,7 +459,7 @@ class FVP_oEmbed {
 		// parse query
 		$query = parse_url( $url, PHP_URL_QUERY );
 		$query_args = array();
-		parse_str( $query, $query_args );
+		parse_str( html_entity_decode($query), $query_args );
 
 		// parse fragment
 		$fragment = parse_url( $url, PHP_URL_FRAGMENT );


### PR DESCRIPTION
i wanted for e.g my url to have following parameter `&background=1&api=1`

only first parameter was working cause api one was wrongly encoded `amp;api`